### PR TITLE
setTimeout to delay the scrollTo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,7 +157,9 @@ export default class HorizontalPicker extends PureComponent<HorizontalPickerProp
         }
 
         const x = defaultIndex * itemWidth;
-        this.refScrollView.current.scrollTo({ x, y: 0, animated: false });
+        setTimeout(() => {
+          this.refScrollView.current.scrollTo({ x, y: 0, animated: false });
+        }, 100);
     }
   }
   


### PR DESCRIPTION
It seems that ScrollView has a layout animation, and without delaying the "scrollTo" It won't scroll to the end of the list.
Using the componentDidMount approach, the delay should be at least 500 ms but delaying "scrollTo" in "onLayoutScrollView" only 1 ms is enough to scroll to the end of a large List (The delay was raised to 100ms to be sure that ScrollView is ready for scrollTo ).

Replacing the ScrollView with FlatList might be a better choice to improve the performance.