### PR TITLE
Don't override the private functions with props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,6 +166,12 @@ export default class HorizontalPicker extends PureComponent<HorizontalPickerProp
     const {
       data,
       renderItem,
+      onScroll,
+      onLayout,
+      onScrollBeginDrag,
+      onScrollEndDrag,
+      onMomentumScrollBegin,
+      onMomentumScrollEnd,
       ...props
     } = this.props;
 


### PR DESCRIPTION
With the spreading of props on the scroll view, the internal event listeners are overridden and the props take priority. That breaks the picker. The prop event handlers are already called within the internal event handlers. Extracting them off props before spreading will prevent them from overriding the internals while still being called as intended.